### PR TITLE
Fix patient name array indexing in template

### DIFF
--- a/SYNDERAI/SYNTHETIC-INSTANCE-GENERATION/twig/templates/patient-eps.fsh.twig
+++ b/SYNDERAI/SYNTHETIC-INSTANCE-GENERATION/twig/templates/patient-eps.fsh.twig
@@ -40,8 +40,8 @@ Usage: #inline
 
 {# *** HTML td 1: name #}
 * name[+].family = "{{ patient.family }}"
-* name[+].given = "{{ patient.given }}"
-* name[+].text = "{{ patient.given ~ " " ~ patient.family }}"
+* name[=].given = "{{ patient.given }}"
+* name[=].text = "{{ patient.given ~ " " ~ patient.family }}"
 {{ addHTML_td(patient.given ~ " " ~ patient.family) }}
 
 {# *** HTML td 2: gender #}


### PR DESCRIPTION
Patient.name.family, given and text should not be separate JSON elements.
Note that I do not know Twig, but I tried to infer it from 'address', which does come out correctly.